### PR TITLE
Relocate friend remove button from search to leaderboard

### DIFF
--- a/app/static/css/dashboard.css
+++ b/app/static/css/dashboard.css
@@ -558,6 +558,8 @@ h2 {
   }
   
   .friend-card {
+    display: flex;
+    align-items: center;
     background: #fff;
     border-radius: 12px;
     padding: 15px;
@@ -565,6 +567,24 @@ h2 {
     box-shadow: 0 2px 8px rgba(0,0,0,0.05);
     position: relative;
     padding-left: 50px;
+  }
+
+  .friend-content {
+    flex: 1;
+  }
+
+  .friend-actions {
+    margin-left: 15px;
+  }
+
+  .friend-badge {
+    display: inline-block;
+    background-color: #95a5a6;
+    color: white;
+    padding: 5px 10px;
+    border-radius: 5px;
+    font-size: 12px;
+    font-weight: bold;
   }
 
   .top-rank {

--- a/app/static/js/friends.js
+++ b/app/static/js/friends.js
@@ -38,7 +38,7 @@ document.addEventListener('DOMContentLoaded', function() {
                   </div>
                   <div>
                     ${user.is_friend ? 
-                      `<button class="remove-btn" data-username="${user.username}">Remove Friend</button>` : 
+                      `<span class="friend-badge">Already Friends</span>` : 
                       `<button class="add-btn" data-username="${user.username}">Add Friend</button>`
                     }
                   </div>
@@ -51,9 +51,6 @@ document.addEventListener('DOMContentLoaded', function() {
                 btn.addEventListener('click', addFriend);
               });
               
-              document.querySelectorAll('.remove-btn').forEach(btn => {
-                btn.addEventListener('click', removeFriend);
-              });
             } else {
               searchResults.innerHTML = '<p class="text-center">No users found</p>';
             }
@@ -90,6 +87,7 @@ document.addEventListener('DOMContentLoaded', function() {
             
             if (leaderboardContainer && currentLeaderboardContainer) {
               currentLeaderboardContainer.innerHTML = leaderboardContainer.innerHTML;
+              attachRemoveListeners();
             }
           }
         })
@@ -155,4 +153,13 @@ document.addEventListener('DOMContentLoaded', function() {
           alert('Error removing friend. Please try again.');
         });
     }
+
+    // Function to attach event listeners to remove buttons in the leaderboard
+    function attachRemoveListeners() {
+      document.querySelectorAll('.friend-card .remove-btn').forEach(btn => {
+        btn.addEventListener('click', removeFriend);
+      });
+    }
+
+    attachRemoveListeners();
   });

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -329,36 +329,38 @@
         <div
           class="friend-card {% if friend.rank == 1 %}top-rank{% endif %} {% if friend.is_current_user %}current-user-card{% endif %}">
           <div class="rank-badge {% if friend.is_current_user %}user-badge{% endif %}">{{ friend.rank }}</div>
-          <div class="friend-name">{{ friend.username }}</div>
 
-          {% if friend.activity == 'No recent activity' %}
-          <p><span class="activity-icon">⏳</span> No workout activity recorded yet.</p>
-          {% else %}
-          <p>
-            {% if friend.activity == 'Strength Training' %}
-            <span class="activity-icon">🏋️</span>
-            {% elif friend.activity == 'Running' %}
-            <span class="activity-icon">🏃‍♂️</span>
-            {% elif friend.activity == 'Cardio' %}
-            <span class="activity-icon">❤️</span>
-            {% elif friend.activity == 'Yoga' %}
-            <span class="activity-icon">🧘</span>
-            {% elif friend.activity == 'Swimming' %}
-            <span class="activity-icon">🏊‍♂️</span>
-            {% elif friend.activity == 'Cycling' %}
-            <span class="activity-icon">🚴‍♀️</span>
-            {% elif friend.activity == 'Mixed' %}
-            <span class="activity-icon">🔄</span>
+          <div class="friend-content">
+            <div class="friend-name">{{ friend.username }}</div>
+
+            {% if friend.activity == 'No recent activity' %}
+            <p><span class="activity-icon">⏳</span> No workout activity recorded yet.</p>
             {% else %}
-            <span class="activity-icon">💪</span>
-            {% endif %}
+            <p>
+              {% if friend.activity == 'Strength Training' %}
+              <span class="activity-icon">🏋️</span>
+              {% elif friend.activity == 'Running' %}
+              <span class="activity-icon">🏃‍♂️</span>
+              {% elif friend.activity == 'Cardio' %}
+              <span class="activity-icon">❤️</span>
+              {% elif friend.activity == 'Yoga' %}
+              <span class="activity-icon">🧘</span>
+              {% elif friend.activity == 'Swimming' %}
+              <span class="activity-icon">🏊‍♂️</span>
+              {% elif friend.activity == 'Cycling' %}
+              <span class="activity-icon">🚴‍♀️</span>
+              {% elif friend.activity == 'Mixed' %}
+              <span class="activity-icon">🔄</span>
+              {% else %}
+              <span class="activity-icon">💪</span>
+              {% endif %}
 
-            Burned <strong>{{ friend.calories }} kcal</strong> in <strong>{{ friend.duration }} minutes</strong>
-            doing {{ friend.activity }}.
-          </p>
+              Burned <strong>{{ friend.calories }} kcal</strong> in <strong>{{ friend.duration }} minutes</strong>
+              doing {{ friend.activity }}.
+            </p>
 
-          {% if friend.shared_days_ago is not none %}
-          <p><small class="text-muted">
+            {% if friend.shared_days_ago is not none %}
+            <p><small class="text-muted">
               {% if friend.shared_days_ago == 0 %}
               Shared today
               {% elif friend.shared_days_ago == 1 %}
@@ -366,8 +368,15 @@
               {% else %}
               Shared {{ friend.shared_days_ago }} days ago
               {% endif %}
-            </small></p>
-          {% endif %}
+              </small></p>
+            {% endif %}
+            {% endif %}
+          </div>
+
+          {% if not friend.is_current_user %}
+          <div class="friend-actions">
+            <button class="remove-btn" data-username="{{ friend.username }}">Remove</button>
+          </div>
           {% endif %}
         </div>
         {% endfor %}
@@ -378,49 +387,51 @@
         {% else %}
         <div class="friend-card current-user-card">
           <div class="rank-badge user-badge">1</div>
-          <div class="friend-name">{{ user.username }} (You)</div>
+          <div class="friend-content"></div>
+            <div class="friend-name">{{ user.username }} (You)</div>
 
-          {% if friends[0].activity == 'No recent activity' %}
-          <p><span class="activity-icon">⏳</span> No workout activity recorded yet.</p>
-          {% else %}
-          <p>
-            {% if friends[0].activity == 'Strength Training' %}
-            <span class="activity-icon">🏋️</span>
-            {% elif friends[0].activity == 'Running' %}
-            <span class="activity-icon">🏃‍♂️</span>
-            {% elif friends[0].activity == 'Cardio' %}
-            <span class="activity-icon">❤️</span>
-            {% elif friends[0].activity == 'Yoga' %}
-            <span class="activity-icon">🧘</span>
-            {% elif friends[0].activity == 'Swimming' %}
-            <span class="activity-icon">🏊‍♂️</span>
-            {% elif friends[0].activity == 'Cycling' %}
-            <span class="activity-icon">🚴‍♀️</span>
-            {% elif friends[0].activity == 'Mixed' %}
-            <span class="activity-icon">🔄</span>
+            {% if friends[0].activity == 'No recent activity' %}
+            <p><span class="activity-icon">⏳</span> No workout activity recorded yet.</p>
             {% else %}
-            <span class="activity-icon">💪</span>
+            <p>
+              {% if friends[0].activity == 'Strength Training' %}
+              <span class="activity-icon">🏋️</span>
+              {% elif friends[0].activity == 'Running' %}
+              <span class="activity-icon">🏃‍♂️</span>
+              {% elif friends[0].activity == 'Cardio' %}
+              <span class="activity-icon">❤️</span>
+              {% elif friends[0].activity == 'Yoga' %}
+              <span class="activity-icon">🧘</span>
+              {% elif friends[0].activity == 'Swimming' %}
+              <span class="activity-icon">🏊‍♂️</span>
+              {% elif friends[0].activity == 'Cycling' %}
+              <span class="activity-icon">🚴‍♀️</span>
+              {% elif friends[0].activity == 'Mixed' %}
+              <span class="activity-icon">🔄</span>
+              {% else %}
+              <span class="activity-icon">💪</span>
+              {% endif %}
+
+              Burned <strong>{{ friends[0].calories }} kcal</strong> in <strong>{{ friends[0].duration }} minutes</strong>
+              doing {{ friends[0].activity }}.
+            </p>
+
+            {% if friends[0].shared_days_ago is not none %}
+            <p><small class="text-muted">
+                {% if friends[0].shared_days_ago == 0 %}
+                Shared today
+                {% elif friends[0].shared_days_ago == 1 %}
+                Shared yesterday
+                {% else %}
+                Shared {{ friends[0].shared_days_ago }} days ago
+                {% endif %}
+              </small></p>
+            {% endif %}
             {% endif %}
 
-            Burned <strong>{{ friends[0].calories }} kcal</strong> in <strong>{{ friends[0].duration }} minutes</strong>
-            doing {{ friends[0].activity }}.
-          </p>
-
-          {% if friends[0].shared_days_ago is not none %}
-          <p><small class="text-muted">
-              {% if friends[0].shared_days_ago == 0 %}
-              Shared today
-              {% elif friends[0].shared_days_ago == 1 %}
-              Shared yesterday
-              {% else %}
-              Shared {{ friends[0].shared_days_ago }} days ago
-              {% endif %}
-            </small></p>
-          {% endif %}
-          {% endif %}
-
-          <div class="text-center mt-3">
-            <p>You'll see how you compare once you add friends. Use the search above to find friends!</p>
+            <div class="text-center mt-3">
+              <p>You'll see how you compare once you add friends. Use the search above to find friends!</p>
+            </div>
           </div>
         </div>
         {% endif %}


### PR DESCRIPTION
This PR improves the friend management UI by relocating the "Remove" button from the search results to the friend cards in the leaderboard.

Changes:
- Modified the leaderboard display to include remove buttons next to each friend card
- Updated the search results to show "Already Friends" badge instead of remove buttons
- Added CSS rules to support the new layout 
- Ensured event listeners are properly attached to all buttons

These changes make it easier for users to manage their friends directly from the leaderboard view.